### PR TITLE
STYLE-001 Fix typos in code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,8 +516,8 @@
   ```javascript
   // bad
   const bad = {
-    foo: 3,
-    bar: 4,
+    "foo": 3,
+    "bar": 4,
     "data-blah": 5,
   };
 
@@ -846,7 +846,7 @@
   const name = `Capt. Janeway`;
 
   // good
-  const name = "Capt. Janeway";
+  const name = 'Capt. Janeway';
   ```
 
 <a name="strings--line-length"></a><a name="6.2"></a>
@@ -887,11 +887,6 @@
     return ["How are you, ", name, "?"].join();
   }
 
-  // bad
-  function sayHi(name) {
-    return `How are you, ${name}?`;
-  }
-
   // good
   function sayHi(name) {
     return `How are you, ${name}?`;
@@ -913,7 +908,6 @@
   const foo = "'this' is \"quoted\"";
 
   // good
-  const foo = "'this' is \"quoted\"";
   const foo = `my name is '${name}'`;
   ```
 
@@ -1358,9 +1352,6 @@
   const itemHeight = (item) => (item.height >= 256 ? item.largeSize : item.smallSize);
 
   // good
-  const itemHeight = (item) => (item.height <= 256 ? item.largeSize : item.smallSize);
-
-  // good
   const itemHeight = (item) => {
     const { height, largeSize, smallSize } = item;
     return height <= 256 ? largeSize : smallSize;
@@ -1662,9 +1653,6 @@
   import foo from "foo";
   // … some other imports … //
   import { named1, named2 } from "foo";
-
-  // good
-  import foo, { named1, named2 } from "foo";
 
   // good
   import foo, { named1, named2 } from "foo";


### PR DESCRIPTION
If I may be so bold, this commit fixes some typos in the code examples in the README.md file.

I also noticed that some of the good code examples match the bad code examples:

[4.8](https://github.com/snap-mobile/style-guide?tab=readme-ov-file#arrays--bracket-newline)

[7.15](https://github.com/snap-mobile/style-guide?tab=readme-ov-file#functions--signature-invocation-indentation)

[8.3](https://github.com/snap-mobile/style-guide?tab=readme-ov-file#arrows--paren-wrap)

[10.8](https://github.com/snap-mobile/style-guide?tab=readme-ov-file#modules--multiline-imports-over-newlines)

[13.7](https://github.com/snap-mobile/style-guide?tab=readme-ov-file#variables--linebreak)